### PR TITLE
test: check cleanup errors

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,11 @@ func TestDefaultConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	// Point Viper to the temp directory with no config file.
 	originalConfigPaths := viper.ConfigFileUsed()
@@ -46,7 +50,11 @@ func TestLoadConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	// Prepare a minimal config file
 	configContent := []byte(`---

--- a/fileproc/walker_test.go
+++ b/fileproc/walker_test.go
@@ -15,7 +15,11 @@ func TestProdWalkerWithIgnore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp root directory: %v", err)
 	}
-	defer os.RemoveAll(rootDir)
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	subDir := filepath.Join(rootDir, "vendor")
 	if err := os.Mkdir(subDir, 0755); err != nil {
@@ -69,7 +73,11 @@ func TestProdWalkerBinaryCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp root directory: %v", err)
 	}
-	defer os.RemoveAll(rootDir)
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	// Create a mock binary file
 	binFile := filepath.Join(rootDir, "somefile.exe")
@@ -108,7 +116,11 @@ func TestProdWalkerSizeLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp root directory: %v", err)
 	}
-	defer os.RemoveAll(rootDir)
+	defer func() {
+		if err := os.RemoveAll(rootDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	// Create a file exceeding the size limit
 	largeFilePath := filepath.Join(rootDir, "largefile.txt")

--- a/fileproc/writer_test.go
+++ b/fileproc/writer_test.go
@@ -46,8 +46,12 @@ func TestStartWriter_Formats(t *testing.T) {
 				t.Fatalf("Failed to create temp file: %v", err)
 			}
 			defer func() {
-				outFile.Close()
-				os.Remove(outFile.Name())
+				if err := outFile.Close(); err != nil {
+					t.Errorf("close temp file: %v", err)
+				}
+				if err := os.Remove(outFile.Name()); err != nil {
+					t.Errorf("remove temp file: %v", err)
+				}
 			}()
 
 			// Prepare channels

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,11 @@ func TestIntegrationFullCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp source directory: %v", err)
 	}
-	defer os.RemoveAll(srcDir)
+	defer func() {
+		if err := os.RemoveAll(srcDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	// Create two test files.
 	file1 := filepath.Join(srcDir, "file1.txt")
@@ -35,8 +39,14 @@ func TestIntegrationFullCLI(t *testing.T) {
 		t.Fatalf("Failed to create temp output file: %v", err)
 	}
 	outFilePath := outFile.Name()
-	outFile.Close()
-	defer os.Remove(outFilePath)
+	if err := outFile.Close(); err != nil {
+		t.Fatalf("close temp file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(outFilePath); err != nil {
+			t.Fatalf("cleanup output file: %v", err)
+		}
+	}()
 
 	// Set up CLI arguments.
 	os.Args = []string{
@@ -78,7 +88,11 @@ func TestIntegrationCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp source directory: %v", err)
 	}
-	defer os.RemoveAll(srcDir)
+	defer func() {
+		if err := os.RemoveAll(srcDir); err != nil {
+			t.Fatalf("cleanup failed: %v", err)
+		}
+	}()
 
 	// Create a large number of small files.
 	for i := 0; i < 1000; i++ {
@@ -94,8 +108,14 @@ func TestIntegrationCancellation(t *testing.T) {
 		t.Fatalf("Failed to create temp output file: %v", err)
 	}
 	outFilePath := outFile.Name()
-	outFile.Close()
-	defer os.Remove(outFilePath)
+	if err := outFile.Close(); err != nil {
+		t.Fatalf("close temp file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(outFilePath); err != nil {
+			t.Fatalf("cleanup output file: %v", err)
+		}
+	}()
 
 	// Set up CLI arguments.
 	os.Args = []string{


### PR DESCRIPTION
## Summary
- handle cleanup errors in tests

## Testing
- `go test ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_68712f9d448c832f820b9eb14d8f6cb6