### PR TITLE
chore(lint): replace docker-based precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,9 @@
 repos:
-  - repo: https://github.com/oxsecurity/megalinter
-    rev: v8.4.2 # Git tag specifying the hook, not mega-linter-runner, version
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.57.2
     hooks:
-      - id: megalinter-incremental # Faster, less thorough
-        stages:
-          - pre-commit
+      - id: golangci-lint
+        args: ["--timeout=5m"]
   - repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-rc.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,22 @@ go build -o gibidify .
 ## Usage
 
 ```bash
-./gibidify -source <source_directory> -destination <output_file> [--prefix="..."] [--suffix="..."]
+./gibidify \
+  -source <source_directory> \
+  -destination <output_file> \
+  -format markdown|json|yaml \
+  -concurrency <num_workers> \
+  --prefix="..." \
+  --suffix="..."
 ```
+
+Flags:
+
+- `-source`: directory to scan.
+- `-destination`: output file path (optional; defaults to `<source>.<format>`).
+- `-format`: output format (`markdown`, `json`, or `yaml`).
+- `-concurrency`: number of concurrent workers.
+- `--prefix` / `--suffix`: optional text blocks.
 
 ## Docker
 

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func setDestination() error {
 }
 
 func startWorkers(ctx context.Context, wg *sync.WaitGroup, fileCh chan string, writeCh chan fileproc.WriteRequest) {
-	for range concurrency {
+	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
## Summary
- fix worker startup loop and document CLI flags
- replace Docker-based MegaLinter with golangci-lint

## Testing
- `go test ./...`
- `pre-commit run --files main.go`


------
https://chatgpt.com/codex/tasks/task_e_68743f147718832fb9fd4bcb616b8088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the usage section in the README with detailed command examples and descriptions of all available CLI flags.

* **Bug Fixes**
  * Corrected the worker spawning logic to properly handle concurrency settings.

* **Chores**
  * Updated pre-commit configuration to use a new linter and improved hook settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->