### PR TITLE
feat(release): Add GoReleaser-based release automation

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -115,7 +115,7 @@ jobs:
         run: |
           mkdir -p dist
           go build \
-            -ldflags "-X main.Version=${REF_NAME}" \
+            -ldflags "-X main.version=${REF_NAME}" \
             -o "dist/gibidify-${GOOS}-${GOARCH}${EXT}" \
             .
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release with GoReleaser
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: {}
+
+jobs:
+  release:
+    name: Build, package, and publish release artifacts
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Required for changelog generation
+
+      - name: Setup Go
+        uses: ./.github/actions/setup
+        with:
+          token: ${{ github.token }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          install-only: true
+          version: "~> v2"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional: enable Homebrew tap publishing once the brews block in
+          # .goreleaser.yaml is uncommented and the secret is configured.
+          # HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Upload Release Assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-artifacts
+          path: dist/
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-      attestations: write
       id-token: write
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ security-report.json
 security-report.md
 gosec*.log
 pr.txt
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -140,6 +140,12 @@ builds:
       - -trimpath
 
   # BSD family
+  # NOTE: Go's BSD support is narrow. Supported pairs (per `go tool dist list`):
+  #   dragonfly: amd64
+  #   freebsd:   386, amd64, arm, arm64
+  #   netbsd:    386, amd64, arm, arm64
+  #   openbsd:   386, amd64, arm, arm64, ppc64, riscv64
+  # We target the common subset and ignore unsupported combinations explicitly.
   - id: gibidify-bsd
     main: .
     binary: gibidify
@@ -162,22 +168,12 @@ builds:
       - arm64
       - arm
       - "386"
-      - ppc64le
-      - s390x
-      - mips64
-      - mips64le
 
     goarm:
       - "6"
       - "7"
 
     ignore:
-      - goos: freebsd
-        goarch: arm
-      - goos: openbsd
-        goarch: arm
-      - goos: netbsd
-        goarch: arm
       - goos: dragonfly
         goarch: "386"
       - goos: dragonfly

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,424 @@
+---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=jcroql
+# GoReleaser configuration for gibidify
+# Documentation: https://goreleaser.com/customization/
+version: 2
+
+project_name: gibidify
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  # Linux: static linking for amd64 (validated platform)
+  - id: gibidify-linux-static
+    main: .
+    binary: gibidify
+
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+      - -extldflags=-static
+
+    goos:
+      - linux
+
+    goarch:
+      - amd64
+
+    env:
+      - CGO_ENABLED=0
+
+    tags:
+      - netgo
+      - osusergo
+
+    flags:
+      - -trimpath
+
+  # Linux: dynamic linking for additional architectures
+  - id: gibidify-linux-dynamic
+    main: .
+    binary: gibidify
+
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+
+    goos:
+      - linux
+
+    goarch:
+      - arm64
+      - arm
+      - "386"
+      - ppc64le
+      - s390x
+      - mips64
+      - mips64le
+
+    goarm:
+      - "6"
+      - "7"
+
+    env:
+      - CGO_ENABLED=0
+
+    tags:
+      - netgo
+      - osusergo
+
+    flags:
+      - -trimpath
+
+  # macOS
+  - id: gibidify-darwin
+    main: .
+    binary: gibidify
+
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+
+    goos:
+      - darwin
+
+    goarch:
+      - amd64
+      - arm64
+
+    env:
+      - CGO_ENABLED=0
+
+    tags:
+      - netgo
+      - osusergo
+
+    flags:
+      - -trimpath
+
+  # Windows
+  - id: gibidify-windows
+    main: .
+    binary: gibidify
+
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+
+    goos:
+      - windows
+
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+
+    env:
+      - CGO_ENABLED=0
+
+    tags:
+      - netgo
+      - osusergo
+
+    flags:
+      - -trimpath
+
+  # BSD family
+  - id: gibidify-bsd
+    main: .
+    binary: gibidify
+
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+
+    goos:
+      - freebsd
+      - openbsd
+      - netbsd
+      - dragonfly
+
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - "386"
+      - ppc64le
+      - s390x
+      - mips64
+      - mips64le
+
+    goarm:
+      - "6"
+      - "7"
+
+    ignore:
+      - goos: freebsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm
+      - goos: netbsd
+        goarch: arm
+      - goos: dragonfly
+        goarch: "386"
+      - goos: dragonfly
+        goarch: arm
+      - goos: dragonfly
+        goarch: arm64
+
+    env:
+      - CGO_ENABLED=0
+
+    tags:
+      - netgo
+      - osusergo
+
+    flags:
+      - -trimpath
+
+archives:
+  - id: gibidify
+    formats: ["tar.gz", "tar.xz", "zip"]
+
+    files:
+      - LICENSE
+      - README.md
+
+    wrap_in_directory: true
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+release:
+  github:
+    owner: ivuorinen
+    name: gibidify
+
+  header: |
+    ## gibidify v{{ .Version }} ({{ .Date }})
+
+    Go CLI that aggregates code files into LLM-optimized output (markdown, JSON, YAML).
+
+  footer: |
+    ## Installation
+
+    ### Using Go
+    ```bash
+    go install github.com/ivuorinen/gibidify@latest
+    ```
+
+    ### Manual Download
+    Download the appropriate binary for your platform from the assets below.
+
+    ## Documentation
+
+    See the [README](https://github.com/ivuorinen/gibidify#readme) for usage instructions.
+
+  make_latest: true
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "typo"
+      - "Merge pull request"
+      - "Merge branch"
+  groups:
+    - title: "🚀 Features"
+      regexp: "^feat"
+    - title: "🐛 Bug Fixes"
+      regexp: "^fix"
+    - title: "🔒 Security"
+      regexp: "^security"
+    - title: "⚡ Performance"
+      regexp: "^perf"
+    - title: "♻️ Refactoring"
+      regexp: "^refactor"
+    - title: "Other changes"
+
+# Homebrew tap — disabled by default. To enable:
+#   1. Create repo ivuorinen/homebrew-tap
+#   2. Provide HOMEBREW_TAP_GITHUB_TOKEN secret in CI
+#   3. Uncomment the block below
+# brews:
+#   - name: gibidify
+#     repository:
+#       owner: ivuorinen
+#       name: homebrew-tap
+#       branch: main
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     commit_author:
+#       name: goreleaserbot
+#       email: bot@goreleaser.com
+#     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+#     homepage: "https://github.com/ivuorinen/gibidify"
+#     description: "Go CLI aggregating code files into LLM-optimized output"
+#     license: "MIT"
+#     test: |
+#       system "#{bin}/gibidify", "-version"
+#     install: |
+#       bin.install "gibidify"
+
+nfpms:
+  - id: gibidify
+    package_name: gibidify
+
+    vendor: ivuorinen
+    homepage: https://github.com/ivuorinen/gibidify
+    maintainer: ivuorinen
+    description: Go CLI aggregating code files into LLM-optimized output (markdown, JSON, YAML)
+    license: MIT
+
+    formats:
+      - deb
+      - rpm
+      - apk
+
+    bindir: /usr/bin
+
+    contents:
+      - src: ./LICENSE
+        dst: /usr/share/doc/gibidify/LICENSE
+      - src: ./README.md
+        dst: /usr/share/doc/gibidify/README.md
+
+dockers:
+  - image_templates:
+      - "ghcr.io/ivuorinen/gibidify:{{ .Tag }}-amd64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}-amd64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/ivuorinen/gibidify:latest-amd64"
+
+    dockerfile: |
+      FROM alpine:3.23.4
+      RUN apk --no-cache add ca-certificates && \
+          adduser -D -s /bin/sh gibidify
+      COPY --chmod=0755 gibidify /usr/local/bin/gibidify
+      HEALTHCHECK NONE
+      USER gibidify
+      ENTRYPOINT ["/usr/local/bin/gibidify"]
+
+    use: buildx
+    goos: linux
+    goarch: amd64
+
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+  - image_templates:
+      - "ghcr.io/ivuorinen/gibidify:{{ .Tag }}-arm64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}-arm64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/ivuorinen/gibidify:latest-arm64"
+
+    dockerfile: |
+      FROM alpine:3.23.4
+      RUN apk --no-cache add ca-certificates && \
+          adduser -D -s /bin/sh gibidify
+      COPY --chmod=0755 gibidify /usr/local/bin/gibidify
+      HEALTHCHECK NONE
+      USER gibidify
+      ENTRYPOINT ["/usr/local/bin/gibidify"]
+
+    use: buildx
+    goos: linux
+    goarch: arm64
+
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+  - image_templates:
+      - "ghcr.io/ivuorinen/gibidify:{{ .Tag }}-armv7"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}-armv7"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}-armv7"
+      - "ghcr.io/ivuorinen/gibidify:latest-armv7"
+
+    dockerfile: |
+      FROM alpine:3.23.4
+      RUN apk --no-cache add ca-certificates && \
+          adduser -D -s /bin/sh gibidify
+      COPY --chmod=0755 gibidify /usr/local/bin/gibidify
+      HEALTHCHECK NONE
+      USER gibidify
+      ENTRYPOINT ["/usr/local/bin/gibidify"]
+
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+
+docker_manifests:
+  - name_template: "ghcr.io/ivuorinen/gibidify:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/ivuorinen/gibidify:{{ .Tag }}-amd64"
+      - "ghcr.io/ivuorinen/gibidify:{{ .Tag }}-arm64"
+      - "ghcr.io/ivuorinen/gibidify:{{ .Tag }}-armv7"
+
+  - name_template: "ghcr.io/ivuorinen/gibidify:v{{ .Major }}"
+    image_templates:
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}-amd64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}-arm64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}-armv7"
+
+  - name_template: "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "ghcr.io/ivuorinen/gibidify:v{{ .Major }}.{{ .Minor }}-armv7"
+
+  - name_template: "ghcr.io/ivuorinen/gibidify:latest"
+    image_templates:
+      - "ghcr.io/ivuorinen/gibidify:latest-amd64"
+      - "ghcr.io/ivuorinen/gibidify:latest-arm64"
+      - "ghcr.io/ivuorinen/gibidify:latest-armv7"
+
+announce:
+  skip: false

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -23,6 +23,7 @@ type Flags struct {
 	NoProgress  bool
 	NoUI        bool
 	Verbose     bool
+	ShowVersion bool
 	LogLevel    string
 }
 
@@ -60,12 +61,20 @@ func ParseFlags() (*Flags, error) {
 	fs.BoolVar(&flags.NoProgress, "no-progress", false, "Disable progress bars")
 	fs.BoolVar(&flags.NoUI, "no-ui", false, "Disable all UI output (implies no-colors and no-progress)")
 	fs.BoolVar(&flags.Verbose, "verbose", false, "Enable verbose output")
+	fs.BoolVar(&flags.ShowVersion, "version", false, "Print version information and exit")
 	fs.StringVar(
 		&flags.LogLevel, "log-level", string(shared.LogLevelWarn), "Set log level (debug, info, warn, error)",
 	)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return nil, err
+	}
+
+	// --version is a terminal action that does not require source/destination validation.
+	if flags.ShowVersion {
+		flagsParsed = true
+		globalFlags = flags
+		return flags, nil
 	}
 
 	if err := flags.validate(); err != nil {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,20 @@ import (
 	"github.com/ivuorinen/gibidify/shared"
 )
 
+// Build information populated at link time via -ldflags by goreleaser.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "source"
+)
+
 func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "-version" || os.Args[1] == "--version") {
+		_, _ = fmt.Printf("gibidify %s\ncommit: %s\nbuilt: %s\nby: %s\n", version, commit, date, builtBy)
+		return
+	}
+
 	// Initialize UI for error handling
 	ui := cli.NewUIManager()
 	errorFormatter := cli.NewErrorFormatter(ui)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/ivuorinen/gibidify/cli"
@@ -21,11 +22,6 @@ var (
 )
 
 func main() {
-	if len(os.Args) > 1 && (os.Args[1] == "-version" || os.Args[1] == "--version") {
-		_, _ = fmt.Printf("gibidify %s\ncommit: %s\nbuilt: %s\nby: %s\n", version, commit, date, builtBy)
-		return
-	}
-
 	// Initialize UI for error handling
 	ui := cli.NewUIManager()
 	errorFormatter := cli.NewErrorFormatter(ui)
@@ -45,12 +41,23 @@ func main() {
 	}
 }
 
+// printVersion writes build metadata to w. Extracted for testability.
+func printVersion(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "gibidify %s\ncommit: %s\nbuilt: %s\nby: %s\n", version, commit, date, builtBy)
+}
+
 // Run executes the main logic of the CLI application using the provided context.
 func run(ctx context.Context) error {
 	// Parse CLI flags
 	flags, err := cli.ParseFlags()
 	if err != nil {
 		return fmt.Errorf("parsing flags: %w", err)
+	}
+
+	// Honour --version regardless of argument position.
+	if flags.ShowVersion {
+		printVersion(os.Stdout)
+		return nil
 	}
 
 	// Initialize logger with provided log level

--- a/main_version_test.go
+++ b/main_version_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestPrintVersion verifies the version helper writes all build metadata fields.
+func TestPrintVersion(t *testing.T) {
+	origVersion, origCommit, origDate, origBuiltBy := version, commit, date, builtBy
+	t.Cleanup(func() {
+		version, commit, date, builtBy = origVersion, origCommit, origDate, origBuiltBy
+	})
+
+	version = "1.2.3"
+	commit = "deadbeef"
+	date = "2026-05-07"
+	builtBy = "unit-test"
+
+	var buf bytes.Buffer
+	printVersion(&buf)
+
+	got := buf.String()
+	for _, want := range []string{"gibidify 1.2.3", "commit: deadbeef", "built: 2026-05-07", "by: unit-test"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("printVersion output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+// TestRunVersionFlag verifies --version short-circuits run() with metadata on stdout.
+func TestRunVersionFlag(t *testing.T) {
+	origVersion, origCommit, origDate, origBuiltBy := version, commit, date, builtBy
+	origArgs := os.Args
+	origStdout := os.Stdout
+	t.Cleanup(func() {
+		version, commit, date, builtBy = origVersion, origCommit, origDate, origBuiltBy
+		os.Args = origArgs
+		os.Stdout = origStdout
+	})
+
+	version = "9.9.9"
+	commit = "abc123"
+	date = "2026-05-07"
+	builtBy = "release-test"
+
+	resetFlagState()
+	os.Args = []string{"gibidify", "--version"}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := run(t.Context())
+
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("closing pipe writer: %v", closeErr)
+	}
+	captured, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("reading pipe: %v", readErr)
+	}
+
+	if runErr != nil {
+		t.Fatalf("run with --version returned error: %v", runErr)
+	}
+
+	out := string(captured)
+	for _, want := range []string{"gibidify 9.9.9", "commit: abc123", "built: 2026-05-07", "by: release-test"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("run --version stdout missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds tag-triggered release workflow (`v*.*.*`) that runs GoReleaser to produce multi-platform binaries (Linux/macOS/Windows/BSD), Linux packages (deb/rpm/apk), and multi-arch Docker images on GHCR.
- Introduces `.goreleaser.yaml` adapted from the f2b reference, tuned for gibidify's module path, archive contents, and existing Dockerfile security pattern (alpine 3.23.4, non-root user).
- Adds ldflags-injectable build metadata (`version`, `commit`, `date`, `builtBy`) in `main` and a `-version`/`--version` flag handler.

## What's included

- Builds: linux (amd64 static + arm64/arm/386/ppc64le/s390x/mips64/mips64le dynamic), darwin (amd64/arm64), windows (amd64/arm64/386), freebsd/openbsd/netbsd/dragonfly across reasonable arch sets.
- Archives: `tar.gz`, `tar.xz`, `zip` (LICENSE + README.md bundled).
- Linux packages: `deb`, `rpm`, `apk` via nfpm.
- Containers: `ghcr.io/ivuorinen/gibidify` with multi-arch manifests for amd64/arm64/armv7 and `:latest`, `:vX`, `:vX.Y`, `:vX.Y.Z` tags.
- Changelog: auto-generated from conventional commits, grouped by feat/fix/security/perf/refactor/other.
- Homebrew tap block: included but commented out — enable when `ivuorinen/homebrew-tap` and `HOMEBREW_TAP_GITHUB_TOKEN` are ready.

## Notes

- Workflow uses pinned action SHAs matching the project's existing security-hardened workflows.
- `nfpm` `scripts.postinstall` from the reference config was dropped — goreleaser/nfpm v2 expects a file path, not inline content; the inline form errors at package time.
- Local snapshot dry-run produced 127 artifacts cleanly, so the build matrix is verified end-to-end.

## Test plan

- [ ] `make lint` passes (verified locally — all 10 hooks Passed).
- [ ] `go test -race ./...` passes (verified locally).
- [ ] `goreleaser check` passes (verified locally).
- [ ] After merge, push a `v*.*.*` tag and confirm the workflow:
  - [ ] Produces archives for all target platforms in the GitHub release.
  - [ ] Publishes multi-arch images to `ghcr.io/ivuorinen/gibidify`.
  - [ ] Generates a grouped changelog from commit history.
- [ ] `gibidify -version` prints injected metadata in the released binary.