### PR TITLE
chore(go): set language floor to 1.25.0 and track toolchain go1.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ivuorinen/gibidify
 
-go 1.27.0
+go 1.25.0
+
+toolchain go1.27.0
 
 require (
 	github.com/fatih/color v1.19.0


### PR DESCRIPTION
Adds a `toolchain` directive so this module keeps receiving Go version updates.

mise is deprecating reading the `go` directive (`idiomatic.go.mod.go-directive`, removed in mise 2026.11.0), and `ivuorinen/renovate-config` no longer bumps `go`. Without a `toolchain` line this module would stop getting Go updates entirely; Renovate proposes `toolchain` updates by default.

The `go` directive is now the language-compatibility floor — the lowest version that still passes `go build ./...` and `go vet ./...`, settled by `go mod tidy` against the dependency graph. `vet` is included for its `stdversion` analyzer, which catches stdlib symbols newer than the declared language version; a plain build accepts those silently.

Verified with tidy + build + vet before commit.